### PR TITLE
Support markdown link format for Linear tickets

### DIFF
--- a/__tests__/main.test.ts
+++ b/__tests__/main.test.ts
@@ -31,6 +31,15 @@ const validData = [
   }
 ]
 
+const validData2 = [
+  {
+    performed_via_github_app: {
+      slug: 'linear'
+    },
+    body: '](https://linear.app/1234).'
+  }
+]
+
 const invalidData = [
   {
     performed_via_github_app: {
@@ -93,6 +102,20 @@ describe('action', () => {
 
   it('successfully finds the linear ticket', async () => {
     mockData = validData
+    await main.run()
+    expect(runMock).toHaveReturned()
+
+    // Verify that all of the core library functions were called correctly
+    expect(debugMock).toHaveBeenNthCalledWith(
+      1,
+      'Searching for Linear ticket link ...'
+    )
+    expect(noticeMock).toHaveBeenCalledWith('Found Linear ticket.')
+    expect(errorMock).not.toHaveBeenCalled()
+  })
+
+  it('successfully finds the linear ticket in revert PR format', async () => {
+    mockData = validData2
     await main.run()
     expect(runMock).toHaveReturned()
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -28958,7 +28958,8 @@ async function run() {
             repo: context.repo.repo
         });
         const linearComment = comments.data.find(comment => comment.performed_via_github_app?.slug === 'linear' &&
-            comment.body?.includes('href="https://linear.app/'));
+            (comment.body?.includes('href="https://linear.app/') ||
+                comment.body?.includes('](https://linear.app/')));
         if (linearComment) {
             core.notice(`Found Linear ticket.`);
         }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,7 +26,8 @@ export async function run(): Promise<void> {
     const linearComment = comments.data.find(
       comment =>
         comment.performed_via_github_app?.slug === 'linear' &&
-        comment.body?.includes('href="https://linear.app/')
+        (comment.body?.includes('href="https://linear.app/') ||
+          comment.body?.includes('](https://linear.app/'))
     )
     if (linearComment) {
       core.notice(`Found Linear ticket.`)


### PR DESCRIPTION
Revert PRs have a Linear comment in a different format, which was breaking the CI step
```
Issue reopened: [XXX-1234 Issue](https://linear.app/1234)
```